### PR TITLE
Date Picker

### DIFF
--- a/CwlViews.xcodeproj/project.pbxproj
+++ b/CwlViews.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		2633589C228AB84600A667FB /* CwlDatePicker_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2633589B228AB84600A667FB /* CwlDatePicker_iOS.swift */; };
+		263358A2228ABDDD00A667FB /* DatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263358A1228ABDDD00A667FB /* DatePickerView.swift */; };
+		263358A5228AD00000A667FB /* CwlDatePickerTesting_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263358A3228ACFFA00A667FB /* CwlDatePickerTesting_iOS.swift */; };
 		26B761EE2289C57F002823A6 /* CwlStepper_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B761ED2289C57F002823A6 /* CwlStepper_iOS.swift */; };
 		26B761F42289D037002823A6 /* StepperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B761F32289D036002823A6 /* StepperView.swift */; };
 		26B761F62289DA6C002823A6 /* CwlStepperTesting_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B761F52289DA6C002823A6 /* CwlStepperTesting_iOS.swift */; };
@@ -346,6 +349,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2633589B228AB84600A667FB /* CwlDatePicker_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlDatePicker_iOS.swift; sourceTree = "<group>"; };
+		263358A1228ABDDD00A667FB /* DatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerView.swift; sourceTree = "<group>"; };
+		263358A3228ACFFA00A667FB /* CwlDatePickerTesting_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlDatePickerTesting_iOS.swift; sourceTree = "<group>"; };
 		26B761ED2289C57F002823A6 /* CwlStepper_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlStepper_iOS.swift; sourceTree = "<group>"; };
 		26B761F32289D036002823A6 /* StepperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepperView.swift; sourceTree = "<group>"; };
 		26B761F52289DA6C002823A6 /* CwlStepperTesting_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlStepperTesting_iOS.swift; sourceTree = "<group>"; };
@@ -1063,6 +1069,7 @@
 				C95A62261EA59F560059D152 /* CwlBarItem_iOS.swift */,
 				C9A18B331E82BCCD00ADDCD4 /* CwlButton_iOS.swift */,
 				C9A18B311E827F9D00ADDCD4 /* CwlControl_iOS.swift */,
+				2633589B228AB84600A667FB /* CwlDatePicker_iOS.swift */,
 				C9F0AC78223731E30051DD43 /* CwlExtendedViewController_iOS.swift */,
 				C940A3B51E877CBD001F1310 /* CwlGestureRecognizer_iOS.swift */,
 				C978CCF41E8747BE00A0BF05 /* CwlImageView_iOS.swift */,
@@ -1125,6 +1132,7 @@
 				C918FD18226B2A9D002C6308 /* CwlBarItemTesting_iOS.swift */,
 				C918FD29226B2A9F002C6308 /* CwlButtonTesting_iOS.swift */,
 				C918FD0C226B2A9C002C6308 /* CwlControlTesting_iOS.swift */,
+				263358A3228ACFFA00A667FB /* CwlDatePickerTesting_iOS.swift */,
 				C918FD1E226B2A9E002C6308 /* CwlExtendedViewControllerTesting_iOS.swift */,
 				C918FD1D226B2A9E002C6308 /* CwlGestureRecognizerTesting_iOS.swift */,
 				C918FD23226B2A9E002C6308 /* CwlImageViewTesting_iOS.swift */,
@@ -1181,6 +1189,7 @@
 				C9BFDF52220FFA38005F4009 /* ButtonView.swift */,
 				C93E06D4220E76D30028DCB2 /* CatalogTable.swift */,
 				C9BFDF5B220FFA4F005F4009 /* ControlView.swift */,
+				263358A1228ABDDD00A667FB /* DatePickerView.swift */,
 				C9BFDF5D220FFB1C005F4009 /* GestureRecognizerView.swift */,
 				C9BFDF5F220FFB2A005F4009 /* ImageView.swift */,
 				C9C30215222529D8005B0FCD /* LayersView.swift */,
@@ -1744,6 +1753,7 @@
 				C9B0D12522225A7B00D2FB42 /* CwlTableView_macOS.swift in Sources */,
 				C95FABC621D4A1C6007CCE78 /* CwlLayer.swift in Sources */,
 				C90BAE96223917A90043948A /* CwlSplitView_macOS.swift in Sources */,
+				2633589C228AB84600A667FB /* CwlDatePicker_iOS.swift in Sources */,
 				C97B16ED21DC429C00F72DB9 /* CwlTextInputTraits_iOS.swift in Sources */,
 				C97A5B5521D59656001D98DD /* CwlWebView.swift in Sources */,
 				C99E96392237C4E8003FD574 /* CwlExtendedView.swift in Sources */,
@@ -1777,6 +1787,7 @@
 				C918FD30226B2A9F002C6308 /* CwlLongPressGestureRecognizerTesting_iOS.swift in Sources */,
 				C9B705FA2068758F00B4CD29 /* CwlBindingParser.swift in Sources */,
 				C918FD32226B2A9F002C6308 /* CwlPageControl.swift in Sources */,
+				263358A5228AD00000A667FB /* CwlDatePickerTesting_iOS.swift in Sources */,
 				C918FD9D226B51E8002C6308 /* CwlPanGestureRecognizerTesting_macOS.swift in Sources */,
 				C918FD3B226B2A9F002C6308 /* CwlSwitchTesting_iOS.swift in Sources */,
 				C918FD8B226B51E8002C6308 /* CwlSliderTesting_macOS.swift in Sources */,
@@ -1880,6 +1891,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C93C7E33220F0534000484E4 /* AlertView.swift in Sources */,
+				263358A2228ABDDD00A667FB /* DatePickerView.swift in Sources */,
 				C9C30216222529D8005B0FCD /* LayersView.swift in Sources */,
 				C9A715A8220FDED100A05C44 /* AboutTab.swift in Sources */,
 				C9BFDF62220FFB46005F4009 /* NavigationBarView.swift in Sources */,

--- a/Sources/CwlViews/Implementations/iOS/CwlDatePicker_iOS.swift
+++ b/Sources/CwlViews/Implementations/iOS/CwlDatePicker_iOS.swift
@@ -1,0 +1,150 @@
+//
+//  CwlDatePicker_iOS.swift
+//  CwlViews
+//
+//  Created by Sye Boddeus on 14/5/19.
+//  Copyright © 2019 Matt Gallagher ( https://www.cocoawithlove.com ). All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+//  fee is hereby granted, provided that the above copyright notice and this permission notice
+//  appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+//  SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+//  AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+//  OF THIS SOFTWARE.
+//
+
+#if os(iOS)
+
+// MARK: - Binder Part 1: Binder
+public class DatePicker: Binder, DatePickerConvertible {
+	public var state: BinderState<Preparer>
+	public required init(type: Preparer.Instance.Type, parameters: Preparer.Parameters, bindings: [Preparer.Binding]) {
+		state = .pending(type: type, parameters: parameters, bindings: bindings)
+	}
+}
+
+// MARK: - Binder Part 2: Binding
+public extension DatePicker {
+	enum Binding: DatePickerBinding {
+		case inheritedBinding(Preparer.Inherited.Binding)
+		
+		// 0. Static bindings are applied at construction and are subsequently immutable.
+
+		// 1. Value bindings may be applied at construction and may subsequently change.
+		case calendar(Dynamic<Calendar>)
+		case countDownDuration(Dynamic<TimeInterval>)
+		case date(Dynamic<SetOrAnimate<Date>>)
+		case datePickerMode(Dynamic<UIDatePicker.Mode>)
+		case locale(Dynamic<Locale?>)
+		case maximumDate(Dynamic<Date?>)
+		case minimumDate(Dynamic<Date?>)
+		case minuteInterval(Dynamic<Int>)
+		// 2. Signal bindings are performed on the object after construction.
+
+		// 3. Action bindings are triggered by the object after construction.
+
+		// 4. Delegate bindings require synchronous evaluation within the object's context.
+	}
+}
+
+// MARK: - Binder Part 3: Preparer
+public extension DatePicker {
+	struct Preparer: BinderEmbedderConstructor /* or BinderDelegateEmbedderConstructor */ {
+		public typealias Binding = DatePicker.Binding
+		public typealias Inherited = Control.Preparer
+		public typealias Instance = UIDatePicker
+		
+		public var inherited = Inherited()
+		public init() {}
+		public func constructStorage(instance: Instance) -> Storage { return Storage() }
+		public func inheritedBinding(from: Binding) -> Inherited.Binding? {
+			if case .inheritedBinding(let b) = from { return b } else { return nil }
+		}
+	}
+}
+
+// MARK: - Binder Part 4: Preparer overrides
+public extension DatePicker.Preparer {
+	func applyBinding(_ binding: Binding, instance: Instance, storage: Storage) -> Lifetime? {
+		switch binding {
+		case .inheritedBinding(let x): return inherited.applyBinding(x, instance: instance, storage: storage)
+		case .calendar(let x): return x.apply(instance) { i, v in i.calendar = v }
+		case .countDownDuration(let x): return x.apply(instance) { i, v in i.countDownDuration = v }
+		case .date(let x): return x.apply(instance) { i, v in i.setDate(v.value, animated: v.isAnimated) }
+		case .datePickerMode(let x): return x.apply(instance) { i, v in i.datePickerMode = v }
+		case .locale(let x): return x.apply(instance) { i, v in i.locale = v }
+		case .maximumDate(let x): return x.apply(instance) { i, v in i.maximumDate = v }
+		case .minimumDate(let x): return x.apply(instance) { i, v in i.minimumDate = v }
+		case .minuteInterval(let x): return x.apply(instance) { i, v in i.minuteInterval = v }
+		}
+	}
+}
+
+// MARK: - Binder Part 5: Storage and Delegate
+extension DatePicker.Preparer {
+	public typealias Storage = Control.Preparer.Storage
+}
+
+// MARK: - Binder Part 6: BindingNames
+extension BindingName where Binding: DatePickerBinding {
+	public typealias DatePickerName<V> = BindingName<V, DatePicker.Binding, Binding>
+			private static func name<V>(_ source: @escaping (V) -> DatePicker.Binding) -> DatePickerName<V> {
+		return DatePickerName<V>(source: source, downcast: Binding.datePickerBinding)
+	}
+}
+public extension BindingName where Binding: DatePickerBinding {
+	static var calendar: DatePickerName<Dynamic<Calendar>> { return .name(DatePicker.Binding.calendar) }
+	static var countDownDuration: DatePickerName<Dynamic<TimeInterval>> { return .name(DatePicker.Binding.countDownDuration) }
+	static var date: DatePickerName<Dynamic<SetOrAnimate<Date>>> { return .name(DatePicker.Binding.date) }
+	static var datePickerMode: DatePickerName<Dynamic<UIDatePicker.Mode>> { return .name(DatePicker.Binding.datePickerMode) }
+	static var locale: DatePickerName<Dynamic<Locale?>> { return .name(DatePicker.Binding.locale) }
+	static var maximumDate: DatePickerName<Dynamic<Date?>> { return .name(DatePicker.Binding.maximumDate) }
+	static var minimumDate: DatePickerName<Dynamic<Date?>> { return .name(DatePicker.Binding.minimumDate) }
+	static var minuteInterval: DatePickerName<Dynamic<Int>> { return .name(DatePicker.Binding.minuteInterval) }
+}
+
+// MARK: - Binder Part 7: Convertible protocols (if constructible)
+public protocol DatePickerConvertible: ControlConvertible {
+	func uiDatePicker() -> DatePicker.Instance
+}
+extension DatePickerConvertible {
+	public func uiControl() -> Control.Instance { return uiDatePicker() }
+}
+extension UIDatePicker: DatePickerConvertible /* , HasDelegate // if Preparer is BinderDelegateEmbedderConstructor */ {
+	public func uiDatePicker() -> DatePicker.Instance { return self }
+}
+public extension DatePicker {
+	func uiDatePicker() -> DatePicker.Instance { return instance() }
+}
+
+// MARK: - Binder Part 8: Downcast protocols
+public protocol DatePickerBinding: ControlBinding {
+	static func datePickerBinding(_ binding: DatePicker.Binding) -> Self
+	func asDatePickerBinding() -> DatePicker.Binding?
+}
+public extension DatePickerBinding {
+	static func controlBinding(_ binding: Control.Binding) -> Self {
+		return datePickerBinding(.inheritedBinding(binding))
+	}
+}
+extension DatePickerBinding where Preparer.Inherited.Binding: DatePickerBinding {
+	func asDatePickerBinding() -> DatePicker.Binding? {
+		return asInheritedBinding()?.asDatePickerBinding()
+	}
+}
+public extension DatePicker.Binding {
+	typealias Preparer = DatePicker.Preparer
+	func asInheritedBinding() -> Preparer.Inherited.Binding? { if case .inheritedBinding(let b) = self { return b } else { return nil } }
+	func asDatePickerBinding() -> DatePicker.Binding? { return self }
+	static func datePickerBinding(_ binding: DatePicker.Binding) -> DatePicker.Binding {
+		return binding
+	}
+}
+
+// MARK: - Binder Part 9: Other supporting types
+
+#endif

--- a/Sources/CwlViewsTesting/iOS/CwlDatePickerTesting_iOS.swift
+++ b/Sources/CwlViewsTesting/iOS/CwlDatePickerTesting_iOS.swift
@@ -1,0 +1,43 @@
+//
+//  CwlDatePickerTesting_iOS.swift
+//  CwlViewsCatalog_iOS
+//
+//  Created by Sye Boddeus on 14/5/19.
+//  Copyright © 2019 Matt Gallagher ( https://www.cocoawithlove.com ). All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+//  fee is hereby granted, provided that the above copyright notice and this permission notice
+//  appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+//  SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+//  AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+//  OF THIS SOFTWARE.
+//
+
+#if os(iOS)
+
+extension BindingParser where Downcast: DatePickerBinding {
+
+	//	0. Static bindings are applied at construction and are subsequently immutable.
+
+	// 1. Value bindings may be applied at construction and may subsequently change.
+	public static var calendar: BindingParser<Dynamic<Calendar>, DatePicker.Binding, Downcast> { return .init(extract: { if case .calendar(let x) = $0 { return x } else { return nil } }, upcast: { $0.asDatePickerBinding() }) }
+	public static var countDownDuration: BindingParser<Dynamic<TimeInterval>, DatePicker.Binding, Downcast> { return .init(extract: { if case .countDownDuration(let x) = $0 { return x } else { return nil } }, upcast: { $0.asDatePickerBinding() }) }
+	public static var date: BindingParser<Dynamic<SetOrAnimate<Date>>, DatePicker.Binding, Downcast> { return .init(extract: { if case .date(let x) = $0 { return x } else { return nil } }, upcast: { $0.asDatePickerBinding() }) }
+	public static var datePickerMode: BindingParser<Dynamic<UIDatePicker.Mode>, DatePicker.Binding, Downcast> { return .init(extract: { if case .datePickerMode(let x) = $0 { return x } else { return nil } }, upcast: { $0.asDatePickerBinding() }) }
+	public static var locale: BindingParser<Dynamic<Locale?>, DatePicker.Binding, Downcast> { return .init(extract: { if case .locale(let x) = $0 { return x } else { return nil } }, upcast: { $0.asDatePickerBinding() }) }
+	public static var maximumDate: BindingParser<Dynamic<Date?>, DatePicker.Binding, Downcast> { return .init(extract: { if case .maximumDate(let x) = $0 { return x } else { return nil } }, upcast: { $0.asDatePickerBinding() }) }
+	public static var minimumDate: BindingParser<Dynamic<Date?>, DatePicker.Binding, Downcast> { return .init(extract: { if case .minimumDate(let x) = $0 { return x } else { return nil } }, upcast: { $0.asDatePickerBinding() }) }
+	public static var minuteInterval: BindingParser<Dynamic<Int>, DatePicker.Binding, Downcast> { return .init(extract: { if case .minuteInterval(let x) = $0 { return x } else { return nil } }, upcast: { $0.asDatePickerBinding() }) }
+
+	// 2. Signal bindings are performed on the object after construction.
+
+	// 3. Action bindings are triggered by the object after construction.
+
+	// 4. Delegate bindings require synchronous evaluation within the object's context.
+}
+
+#endif

--- a/Tests/CwlViewsCatalog_iOS/Sources/CatalogTable.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/CatalogTable.swift
@@ -24,6 +24,7 @@ enum CatalogViewState: CodableContainer, CaseNameCodable {
 	case barButton(BarButtonViewState)
 	case button(ButtonViewState)
 	case control(ControlViewState)
+	case datePicker(DatePickerViewState)
 	case gestureRecognizer(GestureRecognizerViewState)
 	case imageView(ImageViewState)
 	case layers(LayersViewState)
@@ -62,6 +63,7 @@ extension CatalogViewState {
 		case barButton
 		case button
 		case control
+		case datePicker
 		case gestureRecognizer
 		case imageView
 		case layers
@@ -85,6 +87,7 @@ extension CatalogViewState.CaseName: CaseNameDecoder {
 		case .barButton: return NSLocalizedString("BarButton", comment: "")
 		case .button: return NSLocalizedString("Button", comment: "")
 		case .control: return NSLocalizedString("Control", comment: "")
+		case .datePicker: return NSLocalizedString("Date Picker", comment: "")
 		case .gestureRecognizer: return NSLocalizedString("GestureRecognizer", comment: "")
 		case .imageView: return NSLocalizedString("ImageView", comment: "")
 		case .layers: return NSLocalizedString("Layers", comment: "")
@@ -111,6 +114,7 @@ extension CatalogViewState.CaseName: CaseNameDecoder {
 		case .barButton: return .barButton(try container.decodeIfPresent(BarButtonViewState.self, forKey: self) ?? .init())
 		case .button: return .button(try container.decodeIfPresent(ButtonViewState.self, forKey: self) ?? .init())
 		case .control: return .control(try container.decodeIfPresent(ControlViewState.self, forKey: self) ?? .init())
+		case .datePicker: return .datePicker(try container.decodeIfPresent(DatePickerViewState.self, forKey: self) ?? .init())
 		case .gestureRecognizer: return .gestureRecognizer(try container.decodeIfPresent(GestureRecognizerViewState.self, forKey: self) ?? .init())
 		case .imageView: return .imageView(try container.decodeIfPresent(ImageViewState.self, forKey: self) ?? .init())
 		case .layers: return .layers(try container.decodeIfPresent(LayersViewState.self, forKey: self) ?? .init())

--- a/Tests/CwlViewsCatalog_iOS/Sources/CatalogTable.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/CatalogTable.swift
@@ -87,7 +87,7 @@ extension CatalogViewState.CaseName: CaseNameDecoder {
 		case .barButton: return NSLocalizedString("BarButton", comment: "")
 		case .button: return NSLocalizedString("Button", comment: "")
 		case .control: return NSLocalizedString("Control", comment: "")
-		case .datePicker: return NSLocalizedString("Date Picker", comment: "")
+		case .datePicker: return NSLocalizedString("DatePicker", comment: "")
 		case .gestureRecognizer: return NSLocalizedString("GestureRecognizer", comment: "")
 		case .imageView: return NSLocalizedString("ImageView", comment: "")
 		case .layers: return NSLocalizedString("Layers", comment: "")

--- a/Tests/CwlViewsCatalog_iOS/Sources/DatePickerView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/DatePickerView.swift
@@ -1,0 +1,79 @@
+//
+//  DatePickerView.swift
+//  CwlViewsCatalog_iOS
+//
+//  Created by Sye Boddeus on 14/5/19.
+//  Copyright © 2019 Matt Gallagher ( https://www.cocoawithlove.com ). All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+//  fee is hereby granted, provided that the above copyright notice and this permission notice
+//  appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+//  SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+//  AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+//  OF THIS SOFTWARE.
+//
+
+import CwlViews
+
+struct DatePickerViewState: CodableContainer {
+	// Set min as iOS release date
+	static let min: Date? = {
+		let formatter = DateFormatter.dateFormatter
+		return formatter.date(from: "2007/06/29")
+	}()
+	// Set max two years into the future
+	static let max: Date? = {
+		let date = Date()
+		var components = DateComponents()
+		components.setValue(2, for: .year)
+		return Calendar.current.date(byAdding: components, to: date)
+	}()
+	// Set initial date as now
+	static let initial = Date()
+
+	let date: Var<Date>
+	init() {
+		date = Var(DatePickerViewState.initial)
+	}
+}
+
+func datePickerView(_ datePickerViewState: DatePickerViewState, _ navigationItem: NavigationItem) -> ViewControllerConvertible {
+
+	return ViewController(
+		.navigationItem -- navigationItem,
+		.view -- View(
+			.backgroundColor -- .white,
+			.layout -- .center(
+				marginEdges: .allLayout,
+				.view(
+				Label(
+					.text <-- datePickerViewState.date.allChanges().map { DateFormatter.dateFormatter.string(from: $0) },
+					.font -- UIFont.monospacedDigitSystemFont(ofSize: 20, weight: .regular))),
+				.space(),
+				.view(
+					DatePicker(
+						.locale -- Locale.current,
+						.datePickerMode -- .date,
+						.minimumDate -- DatePickerViewState.min,
+						.maximumDate -- DatePickerViewState.max,
+						.date <-- datePickerViewState.date.map { .animate($0) },
+						.action(.valueChanged, \.date) --> datePickerViewState.date.update()
+					)
+				)
+			)
+		)
+	)
+}
+
+private extension DateFormatter {
+	static let dateFormatter: DateFormatter = {
+		let formatter = DateFormatter()
+		formatter.dateFormat = "yyyy/MM/dd"
+		return formatter
+	}()
+}
+

--- a/Tests/CwlViewsCatalog_iOS/Sources/SplitView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/SplitView.swift
@@ -49,19 +49,20 @@ func splitView(_ viewState: SplitViewState) -> ViewControllerConvertible {
 				case .barButton(let state)?: return barButtonView(state, navigationItem)
 				case .button(let state)?: return buttonView(state, navigationItem)
 				case .control(let state)?: return controlView(state, navigationItem)
+				case .datePicker(let state)?: return datePickerView(state, navigationItem)
 				case .gestureRecognizer(let state)?: return gestureRecognizerView(state, navigationItem)
 				case .imageView(let state)?: return imageView(state, navigationItem)
 				case .layers(let state)?: return layersView(state, navigationItem)
 				case .navigationBar(let state)?: return navigationView(state, navigationItem)
 				case .pageViewController(let state)?: return pageView(state, navigationItem)
 				case .searchBar(let state)?: return searchBarView(state, navigationItem)
+				case .segmentedControl(let state)?: return segmentedControlView(state, navigationItem)
 				case .slider(let state)?: return sliderView(state, navigationItem)
 				case .stepper(let state)?: return stepperlView(state, navigationItem)
 				case .switch(let state)?: return switchView(state, navigationItem)
 				case .textField(let state)?: return textFieldView(state, navigationItem)
 				case .textView(let state)?: return textView(state, navigationItem)
 				case .webView(let state)?: return webView(state, navigationItem)
-				case .segmentedControl(let state)?: return segmentedControlView(state, navigationItem)
 				}
 			}.map { .reload([$0]) }
 		),


### PR DESCRIPTION
Two points of interest:

1. In `UIDatePicker` the `countDownDuration` variable is only relevant when `UIDatePicker.datePickerMode == UIDatePicker.Mode.countDownTimer`. As such, would it fit within the goals of CwlViews to wrap the mode enum with `countDownDuration` to make this interface more intuitive? Or is that just needless 'busy work'?
e.g.
`case datePickerMode(Dynamic<UIDatePicker.Mode>)` becomes something like `case datePickerMode(Dynamic<CwlDatePicker.Mode>)` which would have a case like `case countDownTime(TimeInterval?)`?
Hopefully the above question makes sense 🤷‍♂️

2. For this implementation I actually cut out some of the 'hand-written' boiler plate code by using [Sorcery](https://github.com/krzysztofzablocki/Sourcery) to create the tests and `DatePicker.Preparer.appyBinding()` cases.
I am not suggesting adding it as a dependency or including the relevant stencil, but it is a hint for others and something I thought I would highlight out of interest.