### PR TITLE
Progress View

### DIFF
--- a/CwlViews.xcodeproj/project.pbxproj
+++ b/CwlViews.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		26283B5D228B1601002A9F89 /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26283B5C228B1601002A9F89 /* ProgressView.swift */; };
+		26283B5F228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26283B5E228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift */; };
+		263DD190228B0C3500E55451 /* CwlProgressView_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263DD18F228B0C3500E55451 /* CwlProgressView_iOS.swift */; };
 		26B761EE2289C57F002823A6 /* CwlStepper_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B761ED2289C57F002823A6 /* CwlStepper_iOS.swift */; };
 		26B761F42289D037002823A6 /* StepperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B761F32289D036002823A6 /* StepperView.swift */; };
 		26B761F62289DA6C002823A6 /* CwlStepperTesting_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B761F52289DA6C002823A6 /* CwlStepperTesting_iOS.swift */; };
@@ -346,6 +349,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		26283B5C228B1601002A9F89 /* ProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressView.swift; sourceTree = "<group>"; };
+		26283B5E228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlProgressViewTesting_iOS.swift; sourceTree = "<group>"; };
+		263DD18F228B0C3500E55451 /* CwlProgressView_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlProgressView_iOS.swift; sourceTree = "<group>"; };
 		26B761ED2289C57F002823A6 /* CwlStepper_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlStepper_iOS.swift; sourceTree = "<group>"; };
 		26B761F32289D036002823A6 /* StepperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepperView.swift; sourceTree = "<group>"; };
 		26B761F52289DA6C002823A6 /* CwlStepperTesting_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlStepperTesting_iOS.swift; sourceTree = "<group>"; };
@@ -1075,6 +1081,7 @@
 				C997F858206600B0001A7BF8 /* CwlPageViewController_iOS.swift */,
 				C940A3BF1E877DBD001F1310 /* CwlPanGestureRecognizer_iOS.swift */,
 				C940A3B91E877D55001F1310 /* CwlPinchGestureRecognizer_iOS.swift */,
+				263DD18F228B0C3500E55451 /* CwlProgressView_iOS.swift */,
 				C940A3BB1E877D74001F1310 /* CwlRotationGestureRecognizer_iOS.swift */,
 				C940A3C11E877DDA001F1310 /* CwlScreenEdgePanGestureRecognizer_iOS.swift */,
 				C940A3B31E87751B001F1310 /* CwlScrollView_iOS.swift */,
@@ -1137,6 +1144,7 @@
 				C918FD15226B2A9D002C6308 /* CwlPageViewControllerTesting_iOS.swift */,
 				C918FD10226B2A9C002C6308 /* CwlPanGestureRecognizerTesting_iOS.swift */,
 				C918FD16226B2A9D002C6308 /* CwlPinchGestureRecognizerTesting_iOS.swift */,
+				26283B5E228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift */,
 				C918FD21226B2A9E002C6308 /* CwlRotationGestureRecognizerTesting_iOS.swift */,
 				C918FD24226B2A9F002C6308 /* CwlScreenEdgePanGestureRecognizerTesting_iOS.swift */,
 				C918FD07226B2A9B002C6308 /* CwlScrollViewTesting_iOS.swift */,
@@ -1187,6 +1195,7 @@
 				C9F9A34F21DF70F100026DC1 /* main.swift */,
 				C9BFDF61220FFB46005F4009 /* NavigationBarView.swift */,
 				C9BFDF63220FFB50005F4009 /* PageView.swift */,
+				26283B5C228B1601002A9F89 /* ProgressView.swift */,
 				C9BFDF65220FFB5D005F4009 /* SearchBarView.swift */,
 				26E80D30228447E700FC848C /* SegmentedControlView.swift */,
 				C9BFDF67220FFB69005F4009 /* SliderView.swift */,
@@ -1730,6 +1739,7 @@
 				C9A18B391E83E4A600ADDCD4 /* CwlBinderPreparer.swift in Sources */,
 				C97A5B5921D5BE8A001D98DD /* CwlMenu_macOS.swift in Sources */,
 				C9F0AC6D2236736A0051DD43 /* CwlShapeLayer.swift in Sources */,
+				263DD190228B0C3500E55451 /* CwlProgressView_iOS.swift in Sources */,
 				C985C9B521DC7CB600E8FF8B /* CwlTextField_iOS.swift in Sources */,
 				C985C9BA21DC879100E8FF8B /* CwlLabel_iOS.swift in Sources */,
 				26B761EE2289C57F002823A6 /* CwlStepper_iOS.swift in Sources */,
@@ -1798,6 +1808,7 @@
 				C918FD3F226B2A9F002C6308 /* CwlNavigationControllerTesting_iOS.swift in Sources */,
 				C918FD34226B2A9F002C6308 /* CwlControlTesting_iOS.swift in Sources */,
 				C918FD80226B51E8002C6308 /* CwlWebViewTesting.swift in Sources */,
+				26283B5F228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift in Sources */,
 				C918FD2B226B2A9F002C6308 /* CwlSearchBarTesting_iOS.swift in Sources */,
 				C918FD44226B2A9F002C6308 /* CwlViewControllerTesting_iOS.swift in Sources */,
 				C918FD3C226B2A9F002C6308 /* CwlViewTesting_iOS.swift in Sources */,
@@ -1900,6 +1911,7 @@
 				C9BFDF66220FFB5D005F4009 /* SearchBarView.swift in Sources */,
 				C93E06D5220E76D30028DCB2 /* CatalogTable.swift in Sources */,
 				C9BFDF5C220FFA4F005F4009 /* ControlView.swift in Sources */,
+				26283B5D228B1601002A9F89 /* ProgressView.swift in Sources */,
 				C9BFDF53220FFA38005F4009 /* ButtonView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/CwlViews/Implementations/iOS/CwlProgressView_iOS.swift
+++ b/Sources/CwlViews/Implementations/iOS/CwlProgressView_iOS.swift
@@ -35,13 +35,13 @@ public extension ProgressView {
 		// 0. Static bindings are applied at construction and are subsequently immutable.
 
 		// 1. Value bindings may be applied at construction and may subsequently change.
-        case progress(Dynamic<SetOrAnimate<Float>>)
-        case observedProgress(Dynamic<Progress?>)
-        case progressViewStyle(Dynamic<UIProgressView.Style>)
-        case progressTintColor(Dynamic<UIColor?>)
-        case progressImage(Dynamic<UIImage?>)
-        case trackTintColor(Dynamic<UIColor?>)
-        case trackImage(Dynamic<UIImage?>)
+		case progress(Dynamic<SetOrAnimate<Float>>)
+		case observedProgress(Dynamic<Progress?>)
+		case progressViewStyle(Dynamic<UIProgressView.Style>)
+		case progressTintColor(Dynamic<UIColor?>)
+		case progressImage(Dynamic<UIImage?>)
+		case trackTintColor(Dynamic<UIColor?>)
+		case trackImage(Dynamic<UIImage?>)
 
 		// 2. Signal bindings are performed on the object after construction.
 
@@ -72,13 +72,13 @@ public extension ProgressView.Preparer {
 	func applyBinding(_ binding: Binding, instance: Instance, storage: Storage) -> Lifetime? {
 		switch binding {
 		case .inheritedBinding(let x): return inherited.applyBinding(x, instance: instance, storage: storage)
-        case .progress(let x): return x.apply(instance) { i, v in i.setProgress(v.value, animated: v.isAnimated) }
-        case .observedProgress(let x): return x.apply(instance) { i, v in i.observedProgress = v}
-        case .progressViewStyle(let x): return x.apply(instance) { i, v in i.progressViewStyle = v }
-        case .progressTintColor(let x): return x.apply(instance) { i, v in i.progressTintColor = v }
-        case .progressImage(let x): return x.apply(instance) { i, v in i.progressImage = v }
-        case .trackTintColor(let x): return x.apply(instance) { i, v in i.trackTintColor = v }
-        case .trackImage(let x): return x.apply(instance) { i, v in i.trackImage = v }
+		case .progress(let x): return x.apply(instance) { i, v in i.setProgress(v.value, animated: v.isAnimated) }
+		case .observedProgress(let x): return x.apply(instance) { i, v in i.observedProgress = v}
+		case .progressViewStyle(let x): return x.apply(instance) { i, v in i.progressViewStyle = v }
+		case .progressTintColor(let x): return x.apply(instance) { i, v in i.progressTintColor = v }
+		case .progressImage(let x): return x.apply(instance) { i, v in i.progressImage = v }
+		case .trackTintColor(let x): return x.apply(instance) { i, v in i.trackTintColor = v }
+		case .trackImage(let x): return x.apply(instance) { i, v in i.trackImage = v }
         }
 	}
 }
@@ -96,13 +96,13 @@ extension BindingName where Binding: ProgressViewBinding {
 	}
 }
 public extension BindingName where Binding: ProgressViewBinding {
-    static var progress: ProgressViewName<Dynamic<SetOrAnimate<Float>>> { return .name(ProgressView.Binding.progress) }
-    static var observedProgress: ProgressViewName<Dynamic<Progress?>> { return .name(ProgressView.Binding.observedProgress) }
-    static var progressViewStyle: ProgressViewName<Dynamic<UIProgressView.Style>> { return .name(ProgressView.Binding.progressViewStyle) }
-    static var progressTintColor: ProgressViewName<Dynamic<UIColor?>> { return .name(ProgressView.Binding.progressTintColor) }
-    static var progressImage: ProgressViewName<Dynamic<UIImage?>> { return .name(ProgressView.Binding.progressImage) }
-    static var trackTintColor: ProgressViewName<Dynamic<UIColor?>> { return .name(ProgressView.Binding.trackTintColor) }
-    static var trackImage: ProgressViewName<Dynamic<UIImage?>> { return .name(ProgressView.Binding.trackImage) }
+	static var progress: ProgressViewName<Dynamic<SetOrAnimate<Float>>> { return .name(ProgressView.Binding.progress) }
+	static var observedProgress: ProgressViewName<Dynamic<Progress?>> { return .name(ProgressView.Binding.observedProgress) }
+	static var progressViewStyle: ProgressViewName<Dynamic<UIProgressView.Style>> { return .name(ProgressView.Binding.progressViewStyle) }
+	static var progressTintColor: ProgressViewName<Dynamic<UIColor?>> { return .name(ProgressView.Binding.progressTintColor) }
+	static var progressImage: ProgressViewName<Dynamic<UIImage?>> { return .name(ProgressView.Binding.progressImage) }
+	static var trackTintColor: ProgressViewName<Dynamic<UIColor?>> { return .name(ProgressView.Binding.trackTintColor) }
+	static var trackImage: ProgressViewName<Dynamic<UIImage?>> { return .name(ProgressView.Binding.trackImage) }
 }
 
 // MARK: - Binder Part 7: Convertible protocols (if constructible)

--- a/Sources/CwlViews/Implementations/iOS/CwlProgressView_iOS.swift
+++ b/Sources/CwlViews/Implementations/iOS/CwlProgressView_iOS.swift
@@ -1,0 +1,147 @@
+//
+//  CwlProgressView_iOS.swift
+//  CwlViews
+//
+//  Created by Sye Boddeus on 14/5/19.
+//  Copyright © 2019 Matt Gallagher ( https://www.cocoawithlove.com ). All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+//  fee is hereby granted, provided that the above copyright notice and this permission notice
+//  appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+//  SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+//  AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+//  OF THIS SOFTWARE.
+//
+
+#if os(iOS)
+
+// MARK: - Binder Part 1: Binder
+public class ProgressView: Binder, ProgressViewConvertible {
+	public var state: BinderState<Preparer>
+	public required init(type: Preparer.Instance.Type, parameters: Preparer.Parameters, bindings: [Preparer.Binding]) {
+		state = .pending(type: type, parameters: parameters, bindings: bindings)
+	}
+}
+
+// MARK: - Binder Part 2: Binding
+public extension ProgressView {
+	enum Binding: ProgressViewBinding {
+		case inheritedBinding(Preparer.Inherited.Binding)
+		
+		// 0. Static bindings are applied at construction and are subsequently immutable.
+
+		// 1. Value bindings may be applied at construction and may subsequently change.
+        case progress(Dynamic<SetOrAnimate<Float>>)
+        case observedProgress(Dynamic<Progress?>)
+        case progressViewStyle(Dynamic<UIProgressView.Style>)
+        case progressTintColor(Dynamic<UIColor?>)
+        case progressImage(Dynamic<UIImage?>)
+        case trackTintColor(Dynamic<UIColor?>)
+        case trackImage(Dynamic<UIImage?>)
+
+		// 2. Signal bindings are performed on the object after construction.
+
+		// 3. Action bindings are triggered by the object after construction.
+
+		// 4. Delegate bindings require synchronous evaluation within the object's context.
+	}
+}
+
+// MARK: - Binder Part 3: Preparer
+public extension ProgressView {
+	struct Preparer: BinderEmbedderConstructor /* or BinderDelegateEmbedderConstructor */ {
+		public typealias Binding = ProgressView.Binding
+		public typealias Inherited = View.Preparer
+		public typealias Instance = UIProgressView
+
+		public var inherited = Inherited()
+		public init() {}
+		public func constructStorage(instance: Instance) -> Storage { return Storage() }
+		public func inheritedBinding(from: Binding) -> Inherited.Binding? {
+			if case .inheritedBinding(let b) = from { return b } else { return nil }
+		}
+	}
+}
+
+// MARK: - Binder Part 4: Preparer overrides
+public extension ProgressView.Preparer {
+	func applyBinding(_ binding: Binding, instance: Instance, storage: Storage) -> Lifetime? {
+		switch binding {
+		case .inheritedBinding(let x): return inherited.applyBinding(x, instance: instance, storage: storage)
+        case .progress(let x): return x.apply(instance) { i, v in i.setProgress(v.value, animated: v.isAnimated) }
+        case .observedProgress(let x): return x.apply(instance) { i, v in i.observedProgress = v}
+        case .progressViewStyle(let x): return x.apply(instance) { i, v in i.progressViewStyle = v }
+        case .progressTintColor(let x): return x.apply(instance) { i, v in i.progressTintColor = v }
+        case .progressImage(let x): return x.apply(instance) { i, v in i.progressImage = v }
+        case .trackTintColor(let x): return x.apply(instance) { i, v in i.trackTintColor = v }
+        case .trackImage(let x): return x.apply(instance) { i, v in i.trackImage = v }
+        }
+	}
+}
+
+// MARK: - Binder Part 5: Storage and Delegate
+extension ProgressView.Preparer {
+	public typealias Storage = View.Preparer.Storage
+}
+
+// MARK: - Binder Part 6: BindingNames
+extension BindingName where Binding: ProgressViewBinding {
+	public typealias ProgressViewName<V> = BindingName<V, ProgressView.Binding, Binding>
+			private static func name<V>(_ source: @escaping (V) -> ProgressView.Binding) -> ProgressViewName<V> {
+		return ProgressViewName<V>(source: source, downcast: Binding.ProgressViewBinding)
+	}
+}
+public extension BindingName where Binding: ProgressViewBinding {
+    static var progress: ProgressViewName<Dynamic<SetOrAnimate<Float>>> { return .name(ProgressView.Binding.progress) }
+    static var observedProgress: ProgressViewName<Dynamic<Progress?>> { return .name(ProgressView.Binding.observedProgress) }
+    static var progressViewStyle: ProgressViewName<Dynamic<UIProgressView.Style>> { return .name(ProgressView.Binding.progressViewStyle) }
+    static var progressTintColor: ProgressViewName<Dynamic<UIColor?>> { return .name(ProgressView.Binding.progressTintColor) }
+    static var progressImage: ProgressViewName<Dynamic<UIImage?>> { return .name(ProgressView.Binding.progressImage) }
+    static var trackTintColor: ProgressViewName<Dynamic<UIColor?>> { return .name(ProgressView.Binding.trackTintColor) }
+    static var trackImage: ProgressViewName<Dynamic<UIImage?>> { return .name(ProgressView.Binding.trackImage) }
+}
+
+// MARK: - Binder Part 7: Convertible protocols (if constructible)
+public protocol ProgressViewConvertible: ViewConvertible {
+	func uiProgressView() -> ProgressView.Instance
+}
+extension ProgressViewConvertible {
+	public func uiView() -> View.Instance { return uiProgressView() }
+}
+extension UIProgressView: ProgressViewConvertible /* , HasDelegate // if Preparer is BinderDelegateEmbedderConstructor */ {
+	public func uiProgressView() -> ProgressView.Instance { return self }
+}
+public extension ProgressView {
+	func uiProgressView() -> ProgressView.Instance { return instance() }
+}
+
+// MARK: - Binder Part 8: Downcast protocols
+public protocol ProgressViewBinding: ViewBinding {
+	static func ProgressViewBinding(_ binding: ProgressView.Binding) -> Self
+	func asProgressViewBinding() -> ProgressView.Binding?
+}
+public extension ProgressViewBinding {
+	static func viewBinding(_ binding: View.Binding) -> Self {
+		return ProgressViewBinding(.inheritedBinding(binding))
+	}
+}
+extension ProgressViewBinding where Preparer.Inherited.Binding: ProgressViewBinding {
+	func asProgressViewBinding() -> ProgressView.Binding? {
+		return asInheritedBinding()?.asProgressViewBinding()
+	}
+}
+public extension ProgressView.Binding {
+	typealias Preparer = ProgressView.Preparer
+	func asInheritedBinding() -> Preparer.Inherited.Binding? { if case .inheritedBinding(let b) = self { return b } else { return nil } }
+	func asProgressViewBinding() -> ProgressView.Binding? { return self }
+	static func ProgressViewBinding(_ binding: ProgressView.Binding) -> ProgressView.Binding {
+		return binding
+	}
+}
+
+// MARK: - Binder Part 9: Other supporting types
+#endif

--- a/Sources/CwlViewsTesting/iOS/CwlProgressViewTesting_iOS.swift
+++ b/Sources/CwlViewsTesting/iOS/CwlProgressViewTesting_iOS.swift
@@ -1,0 +1,42 @@
+//
+//  CwlProgressViewTesting_iOS.swift
+//  CwlViewsTesting
+//
+//  Created by Sye Boddeus on 14/5/19.
+//  Copyright © 2019 Matt Gallagher ( https://www.cocoawithlove.com ). All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+//  fee is hereby granted, provided that the above copyright notice and this permission notice
+//  appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+//  SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+//  AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+//  OF THIS SOFTWARE.
+//
+
+#if os(iOS)
+
+extension BindingParser where Downcast: ProgressViewBinding {
+    
+    //    0. Static bindings are applied at construction and are subsequently immutable.
+
+    // 1. Value bindings may be applied at construction and may subsequently change.
+    public static var progress: BindingParser<Dynamic<SetOrAnimate<Float>>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progress(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+    public static var observedProgress: BindingParser<Dynamic<Progress?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .observedProgress(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+    public static var progressViewStyle: BindingParser<Dynamic<UIProgressView.Style>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progressViewStyle(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+    public static var progressTintColor: BindingParser<Dynamic<UIColor?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progressTintColor(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+    public static var progressImage: BindingParser<Dynamic<UIImage?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progressImage(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+    public static var trackTintColor: BindingParser<Dynamic<UIColor?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .trackTintColor(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+    public static var trackImage: BindingParser<Dynamic<UIImage?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .trackImage(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+
+    // 2. Signal bindings are performed on the object after construction.
+
+    // 3. Action bindings are triggered by the object after construction.
+
+    // 4. Delegate bindings require synchronous evaluation within the object's context.
+}
+
+#endif

--- a/Sources/CwlViewsTesting/iOS/CwlProgressViewTesting_iOS.swift
+++ b/Sources/CwlViewsTesting/iOS/CwlProgressViewTesting_iOS.swift
@@ -20,23 +20,23 @@
 #if os(iOS)
 
 extension BindingParser where Downcast: ProgressViewBinding {
-    
-    //    0. Static bindings are applied at construction and are subsequently immutable.
 
-    // 1. Value bindings may be applied at construction and may subsequently change.
-    public static var progress: BindingParser<Dynamic<SetOrAnimate<Float>>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progress(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
-    public static var observedProgress: BindingParser<Dynamic<Progress?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .observedProgress(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
-    public static var progressViewStyle: BindingParser<Dynamic<UIProgressView.Style>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progressViewStyle(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
-    public static var progressTintColor: BindingParser<Dynamic<UIColor?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progressTintColor(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
-    public static var progressImage: BindingParser<Dynamic<UIImage?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progressImage(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
-    public static var trackTintColor: BindingParser<Dynamic<UIColor?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .trackTintColor(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
-    public static var trackImage: BindingParser<Dynamic<UIImage?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .trackImage(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+	//    0. Static bindings are applied at construction and are subsequently immutable.
 
-    // 2. Signal bindings are performed on the object after construction.
+	// 1. Value bindings may be applied at construction and may subsequently change.
+	public static var progress: BindingParser<Dynamic<SetOrAnimate<Float>>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progress(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+	public static var observedProgress: BindingParser<Dynamic<Progress?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .observedProgress(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+	public static var progressViewStyle: BindingParser<Dynamic<UIProgressView.Style>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progressViewStyle(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+	public static var progressTintColor: BindingParser<Dynamic<UIColor?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progressTintColor(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+	public static var progressImage: BindingParser<Dynamic<UIImage?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .progressImage(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+	public static var trackTintColor: BindingParser<Dynamic<UIColor?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .trackTintColor(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
+	public static var trackImage: BindingParser<Dynamic<UIImage?>, ProgressView.Binding, Downcast> { return .init(extract: { if case .trackImage(let x) = $0 { return x } else { return nil } }, upcast: { $0.asProgressViewBinding() }) }
 
-    // 3. Action bindings are triggered by the object after construction.
+	// 2. Signal bindings are performed on the object after construction.
 
-    // 4. Delegate bindings require synchronous evaluation within the object's context.
+	// 3. Action bindings are triggered by the object after construction.
+
+	// 4. Delegate bindings require synchronous evaluation within the object's context.
 }
 
 #endif

--- a/Tests/CwlViewsCatalog_iOS/Sources/CatalogTable.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/CatalogTable.swift
@@ -29,6 +29,7 @@ enum CatalogViewState: CodableContainer, CaseNameCodable {
 	case layers(LayersViewState)
 	case navigationBar(NavigationBarViewState)
 	case pageViewController(PageViewState)
+    case progressView(ProgressViewState)
 	case searchBar(SearchBarViewState)
 	case segmentedControl(SegmentedViewState)
 	case slider(SliderViewState)
@@ -67,6 +68,7 @@ extension CatalogViewState {
 		case layers
 		case navigationBar
 		case pageViewController
+        case progressView
 		case searchBar
 		case segmentedControl
 		case slider
@@ -90,6 +92,7 @@ extension CatalogViewState.CaseName: CaseNameDecoder {
 		case .layers: return NSLocalizedString("Layers", comment: "")
 		case .navigationBar: return NSLocalizedString("NavigationBar", comment: "")
 		case .pageViewController: return NSLocalizedString("PageViewController", comment: "")
+        case .progressView: return NSLocalizedString("ProgressView", comment: "")
 		case .searchBar: return NSLocalizedString("SearchBar", comment: "")
 		case .segmentedControl: return NSLocalizedString("SegmentedControl", comment: "")
 		case .slider: return NSLocalizedString("Slider", comment: "")
@@ -116,6 +119,7 @@ extension CatalogViewState.CaseName: CaseNameDecoder {
 		case .layers: return .layers(try container.decodeIfPresent(LayersViewState.self, forKey: self) ?? .init())
 		case .navigationBar: return .navigationBar(try container.decodeIfPresent(NavigationBarViewState.self, forKey: self) ?? .init())
 		case .pageViewController: return .pageViewController(try container.decodeIfPresent(PageViewState.self, forKey: self) ?? .init())
+        case .progressView: return .progressView(try container.decodeIfPresent(ProgressViewState.self, forKey: self) ?? .init())
 		case .searchBar: return .searchBar(try container.decodeIfPresent(SearchBarViewState.self, forKey: self) ?? .init())
 		case .segmentedControl: return .segmentedControl(try container.decodeIfPresent(SegmentedViewState.self, forKey: self) ?? .init())
 		case .slider: return .slider(try container.decodeIfPresent(SliderViewState.self, forKey: self) ?? .init())

--- a/Tests/CwlViewsCatalog_iOS/Sources/CatalogTable.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/CatalogTable.swift
@@ -29,7 +29,7 @@ enum CatalogViewState: CodableContainer, CaseNameCodable {
 	case layers(LayersViewState)
 	case navigationBar(NavigationBarViewState)
 	case pageViewController(PageViewState)
-    case progressView(ProgressViewState)
+	case progressView(ProgressViewState)
 	case searchBar(SearchBarViewState)
 	case segmentedControl(SegmentedViewState)
 	case slider(SliderViewState)
@@ -68,7 +68,7 @@ extension CatalogViewState {
 		case layers
 		case navigationBar
 		case pageViewController
-        case progressView
+		case progressView
 		case searchBar
 		case segmentedControl
 		case slider
@@ -92,7 +92,7 @@ extension CatalogViewState.CaseName: CaseNameDecoder {
 		case .layers: return NSLocalizedString("Layers", comment: "")
 		case .navigationBar: return NSLocalizedString("NavigationBar", comment: "")
 		case .pageViewController: return NSLocalizedString("PageViewController", comment: "")
-        case .progressView: return NSLocalizedString("ProgressView", comment: "")
+		case .progressView: return NSLocalizedString("ProgressView", comment: "")
 		case .searchBar: return NSLocalizedString("SearchBar", comment: "")
 		case .segmentedControl: return NSLocalizedString("SegmentedControl", comment: "")
 		case .slider: return NSLocalizedString("Slider", comment: "")
@@ -119,7 +119,7 @@ extension CatalogViewState.CaseName: CaseNameDecoder {
 		case .layers: return .layers(try container.decodeIfPresent(LayersViewState.self, forKey: self) ?? .init())
 		case .navigationBar: return .navigationBar(try container.decodeIfPresent(NavigationBarViewState.self, forKey: self) ?? .init())
 		case .pageViewController: return .pageViewController(try container.decodeIfPresent(PageViewState.self, forKey: self) ?? .init())
-        case .progressView: return .progressView(try container.decodeIfPresent(ProgressViewState.self, forKey: self) ?? .init())
+		case .progressView: return .progressView(try container.decodeIfPresent(ProgressViewState.self, forKey: self) ?? .init())
 		case .searchBar: return .searchBar(try container.decodeIfPresent(SearchBarViewState.self, forKey: self) ?? .init())
 		case .segmentedControl: return .segmentedControl(try container.decodeIfPresent(SegmentedViewState.self, forKey: self) ?? .init())
 		case .slider: return .slider(try container.decodeIfPresent(SliderViewState.self, forKey: self) ?? .init())

--- a/Tests/CwlViewsCatalog_iOS/Sources/ProgressView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/ProgressView.swift
@@ -1,0 +1,71 @@
+//
+//  ProgressView.swift
+//  CwlViewsCatalog_iOS
+//
+//  Created by Sye Boddeus on 14/5/19.
+//  Copyright © 2019 Matt Gallagher ( https://www.cocoawithlove.com ). All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+//  fee is hereby granted, provided that the above copyright notice and this permission notice
+//  appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+//  SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+//  AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+//  OF THIS SOFTWARE.
+//
+
+import CwlViews
+import QuartzCore
+
+struct ProgressViewState: CodableContainer {
+    init() {
+    }
+}
+
+private class ProgressGenerator {
+    static let shared = ProgressGenerator()
+
+    private var displayLink: CADisplayLink!
+    private var ticker: Float
+
+    let value: Var<Float>
+
+    init() {
+        ticker = 0
+        value = Var(ticker)
+        displayLink = CADisplayLink(target: self, selector: #selector(tick(displayLink:)))
+        displayLink.add(to: .current, forMode: .common)
+        displayLink.preferredFramesPerSecond = 60
+    }
+
+    @objc func tick(displayLink: CADisplayLink) {
+        ticker += 1/300 // ~ Fill up after 5 seconds
+        if ticker >= 1 {
+            ticker = 0
+        }
+
+        value.send(value: .notify(ticker))
+    }
+}
+
+func progressView(_ viewState: ProgressViewState, _ navigationItem: NavigationItem) -> ViewControllerConvertible {
+    return ViewController(
+        .navigationItem -- navigationItem,
+        .view -- View(
+            .backgroundColor -- .white,
+            .layout -- .center(
+                length: 20,
+                .view(
+                    ProgressView(
+                        .trackTintColor -- .green,
+                        .progressImage -- .drawn(width: 10, height: 10) { $0.fillEllipse(in: $1) },
+                        .progress <-- ProgressGenerator.shared.value.map { $0 == 0 ? .set($0) : .animate($0) }
+                    )
+                )
+            )
+        )
+    )
+}

--- a/Tests/CwlViewsCatalog_iOS/Sources/ProgressView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/ProgressView.swift
@@ -26,8 +26,6 @@ struct ProgressViewState: CodableContainer {
 }
 
 private class ProgressGenerator {
-    static let shared = ProgressGenerator()
-
     private var displayLink: CADisplayLink!
     private var ticker: Float
 
@@ -62,7 +60,7 @@ func progressView(_ viewState: ProgressViewState, _ navigationItem: NavigationIt
                     ProgressView(
                         .trackTintColor -- .green,
                         .progressImage -- .drawn(width: 10, height: 10) { $0.fillEllipse(in: $1) },
-                        .progress <-- ProgressGenerator.shared.value.map { $0 == 0 ? .set($0) : .animate($0) }
+                        .progress <-- ProgressGenerator().value.map { $0 == 0 ? .set($0) : .animate($0) }
                     )
                 )
             )

--- a/Tests/CwlViewsCatalog_iOS/Sources/SplitView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/SplitView.swift
@@ -54,6 +54,7 @@ func splitView(_ viewState: SplitViewState) -> ViewControllerConvertible {
 				case .layers(let state)?: return layersView(state, navigationItem)
 				case .navigationBar(let state)?: return navigationView(state, navigationItem)
 				case .pageViewController(let state)?: return pageView(state, navigationItem)
+                case .progressView(let state)?: return progressView(state, navigationItem)
 				case .searchBar(let state)?: return searchBarView(state, navigationItem)
 				case .slider(let state)?: return sliderView(state, navigationItem)
 				case .stepper(let state)?: return stepperlView(state, navigationItem)

--- a/Tests/CwlViewsCatalog_iOS/Sources/SplitView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/SplitView.swift
@@ -54,7 +54,7 @@ func splitView(_ viewState: SplitViewState) -> ViewControllerConvertible {
 				case .layers(let state)?: return layersView(state, navigationItem)
 				case .navigationBar(let state)?: return navigationView(state, navigationItem)
 				case .pageViewController(let state)?: return pageView(state, navigationItem)
-                case .progressView(let state)?: return progressView(state, navigationItem)
+				case .progressView(let state)?: return progressView(state, navigationItem)
 				case .searchBar(let state)?: return searchBarView(state, navigationItem)
 				case .slider(let state)?: return sliderView(state, navigationItem)
 				case .stepper(let state)?: return stepperlView(state, navigationItem)


### PR DESCRIPTION
It would be interesting to investigate providing a single interface for providing progress. `UIProgressView` has two, `observedProgress: Progress?` and `progress: Float`.

For now I have provided the straight forward bindings for both interfaces. But if someone likes the idea of providing one interface, probably a nicer wrapper of `Progress` for the `observedProgress` property on `UIProgressView`,  I would be happy to investigate doing so.