### PR TITLE
[FEEDBACK] Picker iOS

### DIFF
--- a/CwlViews.xcodeproj/project.pbxproj
+++ b/CwlViews.xcodeproj/project.pbxproj
@@ -22,17 +22,20 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		26283B5D228B1601002A9F89 /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26283B5C228B1601002A9F89 /* ProgressView.swift */; };
+		26283B5F228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26283B5E228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift */; };
 		2633589C228AB84600A667FB /* CwlDatePicker_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2633589B228AB84600A667FB /* CwlDatePicker_iOS.swift */; };
 		263358A2228ABDDD00A667FB /* DatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263358A1228ABDDD00A667FB /* DatePickerView.swift */; };
 		263358A5228AD00000A667FB /* CwlDatePickerTesting_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263358A3228ACFFA00A667FB /* CwlDatePickerTesting_iOS.swift */; };
-		26283B5D228B1601002A9F89 /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26283B5C228B1601002A9F89 /* ProgressView.swift */; };
-		26283B5F228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26283B5E228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift */; };
 		263DD190228B0C3500E55451 /* CwlProgressView_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263DD18F228B0C3500E55451 /* CwlProgressView_iOS.swift */; };
 		26B761EE2289C57F002823A6 /* CwlStepper_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B761ED2289C57F002823A6 /* CwlStepper_iOS.swift */; };
 		26B761F42289D037002823A6 /* StepperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B761F32289D036002823A6 /* StepperView.swift */; };
 		26B761F62289DA6C002823A6 /* CwlStepperTesting_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B761F52289DA6C002823A6 /* CwlStepperTesting_iOS.swift */; };
+		26C8F5C0228D9E4E00B4229D /* CwlPickerView_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C8F5BF228D9E4E00B4229D /* CwlPickerView_iOS.swift */; };
 		26E80D2F22843EB000FC848C /* CwlSegmentedControl_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E80D2E22843EB000FC848C /* CwlSegmentedControl_iOS.swift */; };
 		26E80D31228447E700FC848C /* SegmentedControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E80D30228447E700FC848C /* SegmentedControlView.swift */; };
+		26ECF6CC229599CD00B5937A /* CwlPickerViewTesting_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26ECF6C6229599BC00B5937A /* CwlPickerViewTesting_iOS.swift */; };
+		26ECF6CE22959ACD00B5937A /* PickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26ECF6CD22959ACD00B5937A /* PickerView.swift */; };
 		C9033CC221EB5C220077245D /* CwlAdapterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9033CC121EB5C220077245D /* CwlAdapterState.swift */; };
 		C9086A182196502A006DBD43 /* CwlLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92169BF218F083600396AB0 /* CwlLayerTests.swift */; };
 		C909ACA6225CD036006F855D /* CwlImageView_macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C909ACA5225CD036006F855D /* CwlImageView_macOS.swift */; };
@@ -352,17 +355,20 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		26283B5C228B1601002A9F89 /* ProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressView.swift; sourceTree = "<group>"; };
+		26283B5E228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlProgressViewTesting_iOS.swift; sourceTree = "<group>"; };
 		2633589B228AB84600A667FB /* CwlDatePicker_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlDatePicker_iOS.swift; sourceTree = "<group>"; };
 		263358A1228ABDDD00A667FB /* DatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerView.swift; sourceTree = "<group>"; };
 		263358A3228ACFFA00A667FB /* CwlDatePickerTesting_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlDatePickerTesting_iOS.swift; sourceTree = "<group>"; };
-		26283B5C228B1601002A9F89 /* ProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressView.swift; sourceTree = "<group>"; };
-		26283B5E228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlProgressViewTesting_iOS.swift; sourceTree = "<group>"; };
 		263DD18F228B0C3500E55451 /* CwlProgressView_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlProgressView_iOS.swift; sourceTree = "<group>"; };
 		26B761ED2289C57F002823A6 /* CwlStepper_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlStepper_iOS.swift; sourceTree = "<group>"; };
 		26B761F32289D036002823A6 /* StepperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepperView.swift; sourceTree = "<group>"; };
 		26B761F52289DA6C002823A6 /* CwlStepperTesting_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlStepperTesting_iOS.swift; sourceTree = "<group>"; };
+		26C8F5BF228D9E4E00B4229D /* CwlPickerView_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlPickerView_iOS.swift; sourceTree = "<group>"; };
 		26E80D2E22843EB000FC848C /* CwlSegmentedControl_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlSegmentedControl_iOS.swift; sourceTree = "<group>"; };
 		26E80D30228447E700FC848C /* SegmentedControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlView.swift; sourceTree = "<group>"; };
+		26ECF6C6229599BC00B5937A /* CwlPickerViewTesting_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlPickerViewTesting_iOS.swift; sourceTree = "<group>"; };
+		26ECF6CD22959ACD00B5937A /* PickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerView.swift; sourceTree = "<group>"; };
 		C9033CC121EB5C220077245D /* CwlAdapterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlAdapterState.swift; sourceTree = "<group>"; };
 		C909ACA5225CD036006F855D /* CwlImageView_macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlImageView_macOS.swift; sourceTree = "<group>"; };
 		C909ACAB225E0C51006F855D /* CwlSlider_macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CwlSlider_macOS.swift; sourceTree = "<group>"; };
@@ -1087,6 +1093,7 @@
 				C9C302132224DA17005B0FCD /* CwlPageControl.swift */,
 				C997F858206600B0001A7BF8 /* CwlPageViewController_iOS.swift */,
 				C940A3BF1E877DBD001F1310 /* CwlPanGestureRecognizer_iOS.swift */,
+				26C8F5BF228D9E4E00B4229D /* CwlPickerView_iOS.swift */,
 				C940A3B91E877D55001F1310 /* CwlPinchGestureRecognizer_iOS.swift */,
 				263DD18F228B0C3500E55451 /* CwlProgressView_iOS.swift */,
 				C940A3BB1E877D74001F1310 /* CwlRotationGestureRecognizer_iOS.swift */,
@@ -1151,6 +1158,7 @@
 				C918FD0A226B2A9C002C6308 /* CwlPageControl.swift */,
 				C918FD15226B2A9D002C6308 /* CwlPageViewControllerTesting_iOS.swift */,
 				C918FD10226B2A9C002C6308 /* CwlPanGestureRecognizerTesting_iOS.swift */,
+				26ECF6C6229599BC00B5937A /* CwlPickerViewTesting_iOS.swift */,
 				C918FD16226B2A9D002C6308 /* CwlPinchGestureRecognizerTesting_iOS.swift */,
 				26283B5E228B2ED2002A9F89 /* CwlProgressViewTesting_iOS.swift */,
 				C918FD21226B2A9E002C6308 /* CwlRotationGestureRecognizerTesting_iOS.swift */,
@@ -1204,6 +1212,7 @@
 				C9F9A34F21DF70F100026DC1 /* main.swift */,
 				C9BFDF61220FFB46005F4009 /* NavigationBarView.swift */,
 				C9BFDF63220FFB50005F4009 /* PageView.swift */,
+				26ECF6CD22959ACD00B5937A /* PickerView.swift */,
 				26283B5C228B1601002A9F89 /* ProgressView.swift */,
 				C9BFDF65220FFB5D005F4009 /* SearchBarView.swift */,
 				26E80D30228447E700FC848C /* SegmentedControlView.swift */,
@@ -1767,6 +1776,7 @@
 				C97B16ED21DC429C00F72DB9 /* CwlTextInputTraits_iOS.swift in Sources */,
 				C97A5B5521D59656001D98DD /* CwlWebView.swift in Sources */,
 				C99E96392237C4E8003FD574 /* CwlExtendedView.swift in Sources */,
+				26C8F5C0228D9E4E00B4229D /* CwlPickerView_iOS.swift in Sources */,
 				C90A04B1220989FB002ABE89 /* CwlImageDrawn.swift in Sources */,
 				C97B16D121D8E13800F72DB9 /* CwlPressGestureRecognizer_macOS.swift in Sources */,
 				C91307411F66384200174902 /* CwlCoder.swift in Sources */,
@@ -1816,6 +1826,7 @@
 				C918FD4D226B2A9F002C6308 /* CwlAlertControllerTesting_iOS.swift in Sources */,
 				C918FD88226B51E8002C6308 /* CwlViewTesting_macOS.swift in Sources */,
 				C918FD50226B2A9F002C6308 /* CwlNavigationItemTesting_iOS.swift in Sources */,
+				26ECF6CC229599CD00B5937A /* CwlPickerViewTesting_iOS.swift in Sources */,
 				C918FD3F226B2A9F002C6308 /* CwlNavigationControllerTesting_iOS.swift in Sources */,
 				C918FD34226B2A9F002C6308 /* CwlControlTesting_iOS.swift in Sources */,
 				C918FD80226B51E8002C6308 /* CwlWebViewTesting.swift in Sources */,
@@ -1924,6 +1935,7 @@
 				C93E06D5220E76D30028DCB2 /* CatalogTable.swift in Sources */,
 				C9BFDF5C220FFA4F005F4009 /* ControlView.swift in Sources */,
 				26283B5D228B1601002A9F89 /* ProgressView.swift in Sources */,
+				26ECF6CE22959ACD00B5937A /* PickerView.swift in Sources */,
 				C9BFDF53220FFA38005F4009 /* ButtonView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/CwlViews/Implementations/iOS/CwlPickerView_iOS.swift
+++ b/Sources/CwlViews/Implementations/iOS/CwlPickerView_iOS.swift
@@ -292,6 +292,21 @@ public extension BindingName where Binding: PickerViewBinding {
 			downcast: Binding.pickerViewBinding
 		)
 	}
+	static var rowsSelected: PickerViewName<SignalInput<[PickerView<Binding.ViewDataType>.RowComponentAndData]>> {
+		return Binding.compositeName(
+			value: { input in { pickerView, rowAndComponent -> Void in
+				if let components = (pickerView.delegate as? PickerView<Binding.ViewDataType>.Preparer.Storage)?.components {
+					let selected: [PickerView<Binding.ViewDataType>.RowComponentAndData] = (0..<pickerView.numberOfComponents).map {
+						let row = pickerView.selectedRow(inComponent: $0)
+						return ((row: row, component: $0), data: (components.at($0)?.elements.at(row))!)
+					}
+					input.send(value: selected)
+				}
+			} },
+			binding: PickerView.Binding.didSelectRowAndComponent,
+			downcast: Binding.pickerViewBinding
+		)
+	}
 }
 
 // MARK: - Binder Part 7: Convertible protocols (if constructible)

--- a/Sources/CwlViews/Implementations/iOS/CwlPickerView_iOS.swift
+++ b/Sources/CwlViews/Implementations/iOS/CwlPickerView_iOS.swift
@@ -1,0 +1,351 @@
+//
+//  CwlPickerView_iOS.swift
+//  CwlViews
+//
+//  Created by Sye Boddeus on 16/5/19.
+//  Copyright © 2019 Matt Gallagher ( https://www.cocoawithlove.com ). All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+//  fee is hereby granted, provided that the above copyright notice and this permission notice
+//  appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+//  SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+//  AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+//  OF THIS SOFTWARE.
+//
+
+#if os(iOS)
+
+// MARK: - Binder Part 1: Binder
+public class PickerView<ViewData>: Binder, PickerViewConvertible {
+	public var state: BinderState<Preparer>
+	public required init(type: Preparer.Instance.Type, parameters: Preparer.Parameters, bindings: [Preparer.Binding]) {
+		state = .pending(type: type, parameters: parameters, bindings: bindings)
+	}
+}
+
+// MARK: - Binder Part 2: Binding
+public extension PickerView {
+	enum Binding: PickerViewBinding {
+		public typealias ViewDataType = ViewData
+		case inheritedBinding(Preparer.Inherited.Binding)
+		
+		// 0. Static bindings are applied at construction and are subsequently immutable.
+
+		// 1. Value bindings may be applied at construction and may subsequently change.
+		case showsSelectionIndicator(Dynamic<Bool>)
+		case pickerData(Dynamic<PickerComponentMutation<PickerComponent<ViewData>>>)
+
+		// 2. Signal bindings are performed on the object after construction.
+		case selectRowAndComponent(Signal<SetOrAnimate<PickerRowAndComponent>>)
+		case reload(Signal<PickerView.Reload>)
+
+		// 3. Action bindings are triggered by the object after construction.
+
+		// 4. Delegate bindings require synchronous evaluation within the object's context.
+		case didSelectRowAndComponent((_ pickerView: UIPickerView, _ rowAndComponent: PickerRowAndComponent) -> Void)
+		// Do we want to make the below have view re-use? (some how) *****************************
+		case viewConstructor((_ rowSignal: SignalMulti<ViewData>) -> ViewConvertible)
+	}
+}
+
+// MARK: - Binder Part 3: Preparer
+public extension PickerView {
+	struct Preparer: BinderDelegateEmbedderConstructor {
+		public typealias Binding = PickerView.Binding
+		public typealias Inherited = View.Preparer
+		public typealias Instance = UIPickerView
+		
+		public var inherited = Inherited()
+		public var dynamicDelegate: Delegate? = nil
+		public let delegateClass: Delegate.Type
+		public init(delegateClass: Delegate.Type) {
+			self.delegateClass = delegateClass
+		}
+
+		public func constructStorage(instance: Instance) -> Storage { return Storage() }
+		public func inheritedBinding(from: Binding) -> Inherited.Binding? {
+			if case .inheritedBinding(let b) = from { return b } else { return nil }
+		}
+	}
+}
+
+// MARK: - Binder Part 4: Preparer overrides
+public extension PickerView.Preparer {
+	var delegateIsRequired: Bool { return true }
+
+	mutating func prepareBinding(_ binding: Binding) {
+		switch binding {
+		case .inheritedBinding(let x): inherited.prepareBinding(x)
+		case .didSelectRowAndComponent(let x): delegate().addMultiHandler2(x, #selector(UIPickerViewDelegate.pickerView(_:didSelectRow:inComponent:)))
+		default: break
+		}
+	}
+
+	func prepareInstance(_ instance: Instance, storage: Storage) {
+		inheritedPrepareInstance(instance, storage: storage)
+
+		prepareDelegate(instance: instance, storage: storage)
+		instance.dataSource = storage
+	}
+
+	func applyBinding(_ binding: Binding, instance: Instance, storage: Storage) -> Lifetime? {
+		switch binding {
+		case .inheritedBinding(let x): return inherited.applyBinding(x, instance: instance, storage: storage)
+
+		// 1.
+		case .showsSelectionIndicator(let x): return x.apply(instance) { i, v in i.showsSelectionIndicator = v }
+		case .pickerData(let x): return x.apply(instance, storage) { i, s, v in s.applyComponents(v, to: i) }
+
+		// 2.
+		case .selectRowAndComponent(let x): return x.apply(instance) { i, v in i.selectRow(v.value.row, inComponent: v.value.component, animated: v.isAnimated) }
+		case .reload(let x): return x.apply(instance) { i, v in
+			switch v {
+			case .all:
+				i.reloadAllComponents()
+			case .component(let component):
+				i.reloadComponent(component)
+			}
+		}
+
+		// 4. Delegate Bindings
+		case .didSelectRowAndComponent(_): return nil
+		case .viewConstructor(let x):
+			storage.viewConstructor = x
+			return nil
+		}
+	}
+}
+
+// MARK: - Binder Part 5: Storage and Delegate
+extension PickerView.Preparer {
+
+	open class Storage: View.Preparer.Storage, UIPickerViewDelegate, UIPickerViewDataSource {
+		open override var isInUse: Bool { return true }
+
+		open var components = PickerComponentState<PickerComponent<ViewData>>()
+		open var viewConstructor: ((SignalMulti<ViewData>) -> ViewConvertible)?
+
+		// Data Source
+		open func numberOfComponents(in pickerView: UIPickerView) -> Int {
+			return components.count
+		}
+
+		open func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+			return components.at(component)?.elements.count ?? 0
+		}
+
+		// Delegate
+		open func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+			if let element = components.at(component)?.elements.at(row) {
+				switch element {
+				case .text(let x):
+					let label = UILabel()
+					label.text = x
+					label.textAlignment = .center
+					return label
+				case .attributedText(let x):
+					let label = UILabel()
+					label.attributedText = x
+					label.textAlignment = .center
+					return label
+				case .view(let x): assertionFailure("Not yet implemented"); return UIView()
+				}
+			}
+			// We don't seem to have such an element so return an view
+			return UIView()
+		}
+
+		open func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+			return components.at(component)?.rowHeight ?? 0
+		}
+
+		open func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+			return components.at(component)?.width ?? 0
+		}
+
+		// Helpers
+		open func applyComponents(_ componentMutation: PickerComponentMutation<PickerComponent<ViewData>>, to i: UIPickerView) {
+			componentMutation.insertionsAndRemovals(length: components.count,
+													insert: { index, component in
+														components.insert(component, at: index)
+														i.reloadComponent(index)
+													},
+													remove: { index in
+														components.remove(at: index)
+														i.reloadAllComponents()
+			})
+		}
+
+	}
+
+	open class Delegate: DynamicDelegate, UIPickerViewDelegate, UIPickerViewDataSource {
+		open func numberOfComponents(in pickerView: UIPickerView) -> Int {
+			return 0
+		}
+
+		open func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+			return 0
+		}
+
+		// Delegate
+		open func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+			return nil
+		}
+
+		open func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+			return UIView()
+		}
+
+		open func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
+			return nil
+		}
+
+		open func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+			return 0
+		}
+
+		open func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+			return 0
+		}
+
+		open func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+			return multiHandler(pickerView, PickerRowAndComponent(row, component))
+		}
+	}
+
+}
+
+// MARK: - Binder Part 6: BindingNames
+extension BindingName where Binding: PickerViewBinding {
+	public typealias PickerViewName<V> = BindingName<V, PickerView<Binding.ViewDataType>.Binding, Binding>
+	private static func name<V>(_ source: @escaping (V) -> PickerView<Binding.ViewDataType>.Binding) -> PickerViewName<V> {
+		return PickerViewName<V>(source: source, downcast: Binding.pickerViewBinding)
+	}
+}
+public extension BindingName where Binding: PickerViewBinding {
+	// You can easily convert the `Binding` cases to `BindingName` using the following Xcode-style regex:
+	// Replace: case ([^\(]+)\((.+)\)$
+	// With:    static var $1: PickerViewName<$2> { return .name(PickerView.Binding.$1) }
+	// 1. Value bindings may be applied at construction and may subsequently change.
+	static var showsSelectionIndicator: PickerViewName<Dynamic<Bool>> { return .name(PickerView.Binding.showsSelectionIndicator) }
+	static var pickerData: PickerViewName<Dynamic<PickerComponentMutation<PickerComponent<Binding.ViewDataType>>>> { return .name(PickerView.Binding.pickerData) }
+
+	// 2. Signal bindings are performed on the object after construction.
+	static var selectRowAndComponent: PickerViewName<Signal<SetOrAnimate<PickerRowAndComponent>>> { return .name(PickerView.Binding.selectRowAndComponent) }
+	static var reload: PickerViewName<Signal<PickerView<Binding.ViewDataType>.Reload>> { return .name(PickerView.Binding.reload) }
+
+	// 3. Action bindings are triggered by the object after construction.
+
+	// 4. Delegate bindings require synchronous evaluation within the object's context.
+	static var didSelectRowAndComponent: PickerViewName<(_ pickerView: UIPickerView, _ rowAndComponent: PickerRowAndComponent) -> Void> { return .name(PickerView.Binding.didSelectRowAndComponent) }
+	// Do we want to make the below have view re-use? (some how) *****************************
+	static var viewConstructor: PickerViewName<(_ rowSignal: SignalMulti<Binding.ViewDataType>) -> ViewConvertible> { return .name(PickerView.Binding.viewConstructor) }
+
+	// Composite binding names
+	static var rowSelected: PickerViewName<SignalInput<PickerRowAndComponent>> {
+		return Binding.compositeName(
+			value: { input in { picker, rowAndComponent -> Void in input.send(value: rowAndComponent) } },
+			binding: PickerView.Binding.didSelectRowAndComponent,
+			downcast: Binding.pickerViewBinding
+		)
+	}
+//	static func rowSelected(_ void: Void = ()) -> PickerViewName<SignalInput<PickerRowAndComponent>> {
+//		return Binding.compositeName(
+//			value: { input in { picker, rowAndComponent -> Void in input.send(value: rowAndComponent) } },
+//			binding: PickerView.Binding.didSelectRowAndComponent,
+//			downcast: Binding.pickerViewBinding
+//		)
+//	}
+}
+
+// MARK: - Binder Part 7: Convertible protocols (if constructible)
+public protocol PickerViewConvertible: ViewConvertible {
+	func uiPickerView() -> UIPickerView
+}
+extension PickerViewConvertible {
+	public func uiView() -> View.Instance { return uiPickerView() }
+}
+extension UIPickerView: PickerViewConvertible, HasDelegate {
+	public func uiPickerView() -> UIPickerView { return self }
+}
+public extension PickerView {
+	func uiPickerView() -> PickerView.Instance { return instance() }
+}
+
+// MARK: - Binder Part 8: Downcast protocols
+public protocol PickerViewBinding: ViewBinding {
+	associatedtype ViewDataType
+	static func pickerViewBinding(_ binding: PickerView<ViewDataType>.Binding) -> Self
+	func asPickerViewBinding() -> PickerView<ViewDataType>.Binding?
+}
+public extension PickerViewBinding {
+	static func viewBinding(_ binding: View.Binding) -> Self {
+		return pickerViewBinding(.inheritedBinding(binding))
+	}
+}
+public extension PickerViewBinding where Preparer.Inherited.Binding: PickerViewBinding, Preparer.Inherited.Binding.ViewDataType == ViewDataType {
+	func asPickerViewBinding() -> PickerView<ViewDataType>.Binding? {
+		return asInheritedBinding()?.asPickerViewBinding()
+	}
+}
+public extension PickerView.Binding {
+	typealias Preparer = PickerView.Preparer
+	func asInheritedBinding() -> Preparer.Inherited.Binding? { if case .inheritedBinding(let b) = self { return b } else { return nil } }
+	func asPickerViewBinding() -> PickerView.Binding? { return self }
+	static func pickerViewBinding(_ binding: PickerView<ViewDataType>.Binding) -> PickerView<ViewDataType>.Binding {
+		return binding
+	}
+}
+
+// MARK: - Binder Part 9: Other supporting types
+public typealias PickerRowAndComponent = (row: Int, component: Int)
+
+public extension PickerView {
+	enum Reload {
+		case all
+		case component(Int)
+	}
+}
+
+public typealias PickerComponentMutation<Element> = ArrayMutation<Element>
+
+public typealias PickerComponentState<Element> = Array<Element>
+
+public struct PickerComponent<ElementData> {
+	public enum ComponentType {
+		case text(String)
+		case attributedText(NSAttributedString)
+		case view(ElementData)
+	}
+
+	let width: CGFloat
+	let rowHeight: CGFloat
+	let elements: [PickerComponent.ComponentType]
+
+	public init(width: CGFloat = 100,
+				rowHeight: CGFloat = 50,
+				elements: [PickerComponent.ComponentType]) {
+		self.width = width
+		self.rowHeight = rowHeight
+		self.elements = elements
+	}
+}
+
+#endif
+
+
+// MARK: - Binder Part 10: Test support
+
+
+
+//#if canImport(CwlViews)
+//	extension BindingParser where Downcast: ViewSubclassBinding {
+//		// You can easily convert the `Binding` cases to `BindingParser` using the following Xcode-style regex:
+//		// Replace: case ([^\(]+)\((.+)\)$
+//		// With:    public static var $1: BindingParser<$2, ViewSubclass.Binding, Downcast> { return .init(extract: { if case .$1(let x) = \$0 { return x } else { return nil } }, upcast: { \$0.asViewSubclassBinding() }) }
+//	}
+//#endif

--- a/Sources/CwlViewsTesting/iOS/CwlPickerViewTesting_iOS.swift
+++ b/Sources/CwlViewsTesting/iOS/CwlPickerViewTesting_iOS.swift
@@ -1,0 +1,20 @@
+//
+//  CwlPickerViewTesting_iOS.swift
+//  CwlViewsCatalog_iOS
+//
+//  Created by Sye Boddeus on 22/5/19.
+//  Copyright © 2019 Matt Gallagher ( https://www.cocoawithlove.com ). All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+//  fee is hereby granted, provided that the above copyright notice and this permission notice
+//  appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+//  SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+//  AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+//  OF THIS SOFTWARE.
+//
+
+import Foundation

--- a/Sources/CwlViewsTesting/iOS/CwlPickerViewTesting_iOS.swift
+++ b/Sources/CwlViewsTesting/iOS/CwlPickerViewTesting_iOS.swift
@@ -24,17 +24,20 @@ extension BindingParser where Downcast: PickerViewBinding {
 
 	// 1. Value bindings may be applied at construction and may subsequently change.
 	public static var showsSelectionIndicator: BindingParser<Dynamic<Bool>, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .showsSelectionIndicator(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
-	public static var pickerData: BindingParser<Dynamic<PickerComponentMutation<PickerComponent<Downcast.ViewDataType>>>, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .pickerData(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+	public static var pickerData: BindingParser<Dynamic<ArrayMutation<PickerComponent<Downcast.ViewDataType>>>, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .pickerData(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
 
 	// 2. Signal bindings are performed on the object after construction.
-	public static var selectRowAndComponent: BindingParser<Signal<SetOrAnimate<PickerRowAndComponent>>, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .selectRowAndComponent(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+	public static var selectRowAndComponent: BindingParser<Signal<SetOrAnimate<PickerView<Downcast.ViewDataType>.RowAndComponent>>, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .selectRowAndComponent(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
 	public static var reload: BindingParser<Signal<PickerView<Downcast.ViewDataType>.Reload>, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .reload(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
 
 	// 3. Action bindings are triggered by the object after construction.
 
 	// 4. Delegate bindings require synchronous evaluation within the object's context.
-	public static var didSelectRowAndComponent: BindingParser<(_ pickerView: UIPickerView, _ rowAndComponent: PickerRowAndComponent) -> Void, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .didSelectRowAndComponent(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
-	public static var viewConstructor: BindingParser<(_ rowSignal: SignalMulti<Downcast.ViewDataType>) -> ViewConvertible, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .viewConstructor(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+	// Pass in the row signal instead of row and component index because passing in those would circumvent the need for the pickerData
+	public static var attributedTitle: BindingParser<(_ rowComponentAndData: PickerView<Downcast.ViewDataType>.RowComponentAndData) -> NSAttributedString?, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .attributedTitle(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+	public static var didSelectRowAndComponent: BindingParser<(_ pickerView: UIPickerView, _ rowComponentAndData: PickerView<Downcast.ViewDataType>.RowComponentAndData) -> Void, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .didSelectRowAndComponent(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+	public static var title: BindingParser<(_ rowComponentAndData: PickerView<Downcast.ViewDataType>.RowComponentAndData) -> String?, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .title(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+	public static var viewConstructor: BindingParser<(_ rowSignal: SignalMulti<PickerView<Downcast.ViewDataType>.RowComponentAndData>) -> ViewConvertible, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .viewConstructor(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
 }
 
 #endif

--- a/Sources/CwlViewsTesting/iOS/CwlPickerViewTesting_iOS.swift
+++ b/Sources/CwlViewsTesting/iOS/CwlPickerViewTesting_iOS.swift
@@ -17,4 +17,24 @@
 //  OF THIS SOFTWARE.
 //
 
-import Foundation
+#if os(iOS)
+
+extension BindingParser where Downcast: PickerViewBinding {
+	// 0. Static bindings are applied at construction and are subsequently immutable.
+
+	// 1. Value bindings may be applied at construction and may subsequently change.
+	public static var showsSelectionIndicator: BindingParser<Dynamic<Bool>, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .showsSelectionIndicator(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+	public static var pickerData: BindingParser<Dynamic<PickerComponentMutation<PickerComponent<Downcast.ViewDataType>>>, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .pickerData(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+
+	// 2. Signal bindings are performed on the object after construction.
+	public static var selectRowAndComponent: BindingParser<Signal<SetOrAnimate<PickerRowAndComponent>>, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .selectRowAndComponent(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+	public static var reload: BindingParser<Signal<PickerView<Downcast.ViewDataType>.Reload>, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .reload(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+
+	// 3. Action bindings are triggered by the object after construction.
+
+	// 4. Delegate bindings require synchronous evaluation within the object's context.
+	public static var didSelectRowAndComponent: BindingParser<(_ pickerView: UIPickerView, _ rowAndComponent: PickerRowAndComponent) -> Void, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .didSelectRowAndComponent(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+	public static var viewConstructor: BindingParser<(_ rowSignal: SignalMulti<Downcast.ViewDataType>) -> ViewConvertible, PickerView<Downcast.ViewDataType>.Binding, Downcast> { return .init(extract: { if case .viewConstructor(let x) = $0 { return x } else { return nil } }, upcast: { $0.asPickerViewBinding() }) }
+}
+
+#endif

--- a/Tests/CwlViewsCatalog_iOS/Sources/CatalogTable.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/CatalogTable.swift
@@ -30,6 +30,7 @@ enum CatalogViewState: CodableContainer, CaseNameCodable {
 	case layers(LayersViewState)
 	case navigationBar(NavigationBarViewState)
 	case pageViewController(PageViewState)
+	case pickerView(PickerViewState)
 	case progressView(ProgressViewState)
 	case searchBar(SearchBarViewState)
 	case segmentedControl(SegmentedViewState)
@@ -70,6 +71,7 @@ extension CatalogViewState {
 		case layers
 		case navigationBar
 		case pageViewController
+		case pickerView
 		case progressView
 		case searchBar
 		case segmentedControl
@@ -95,6 +97,7 @@ extension CatalogViewState.CaseName: CaseNameDecoder {
 		case .layers: return NSLocalizedString("Layers", comment: "")
 		case .navigationBar: return NSLocalizedString("NavigationBar", comment: "")
 		case .pageViewController: return NSLocalizedString("PageViewController", comment: "")
+		case .pickerView: return NSLocalizedString("PickerView", comment: "")
 		case .progressView: return NSLocalizedString("ProgressView", comment: "")
 		case .searchBar: return NSLocalizedString("SearchBar", comment: "")
 		case .segmentedControl: return NSLocalizedString("SegmentedControl", comment: "")
@@ -123,6 +126,7 @@ extension CatalogViewState.CaseName: CaseNameDecoder {
 		case .layers: return .layers(try container.decodeIfPresent(LayersViewState.self, forKey: self) ?? .init())
 		case .navigationBar: return .navigationBar(try container.decodeIfPresent(NavigationBarViewState.self, forKey: self) ?? .init())
 		case .pageViewController: return .pageViewController(try container.decodeIfPresent(PageViewState.self, forKey: self) ?? .init())
+		case .pickerView: return .pickerView(try container.decodeIfPresent(PickerViewState.self, forKey: self) ?? .init())
 		case .progressView: return .progressView(try container.decodeIfPresent(ProgressViewState.self, forKey: self) ?? .init())
 		case .searchBar: return .searchBar(try container.decodeIfPresent(SearchBarViewState.self, forKey: self) ?? .init())
 		case .segmentedControl: return .segmentedControl(try container.decodeIfPresent(SegmentedViewState.self, forKey: self) ?? .init())

--- a/Tests/CwlViewsCatalog_iOS/Sources/PickerView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/PickerView.swift
@@ -20,9 +20,9 @@
 import CwlViews
 
 struct PickerViewState: CodableContainer {
-	var selectedRow: TempVar<PickerView<String>.RowComponentAndData>
+	var selectedRow: TempVar<[PickerView<String>.RowComponentAndData]>
 	init() {
-		selectedRow = TempVar<PickerView<String>.RowComponentAndData>()
+		selectedRow = TempVar<[PickerView<String>.RowComponentAndData]>()
 	}
 }
 
@@ -35,7 +35,7 @@ func pickerView(_ viewState: PickerViewState, _ navigationItem: NavigationItem) 
 				marginEdges: .allLayout,
 				.view(
 					Label(
-						.text <-- viewState.selectedRow.map { value in return "\(value.data)"},
+						.text <-- viewState.selectedRow.map { $0.reduce("") { result, next in result + "\(next.data)\t"  } },
 						.font -- UIFont.monospacedDigitSystemFont(ofSize: 17, weight: .regular)
 					)
 				),
@@ -44,7 +44,7 @@ func pickerView(_ viewState: PickerViewState, _ navigationItem: NavigationItem) 
 					PickerView<String>(
 						.backgroundColor -- .red,
 						.pickerData -- .reload([PickerComponent<String>(elements: ["1", "2", "3", "4"]), PickerComponent<String>(elements: ["1", "2", "3", "4"])]),
-						.rowSelected --> viewState.selectedRow,
+						.rowsSelected --> viewState.selectedRow,
 						.title -- { $0.data }
 //						.viewConstructor -- { data in
 //							Label(.text <-- data.map { $0.data})

--- a/Tests/CwlViewsCatalog_iOS/Sources/PickerView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/PickerView.swift
@@ -20,22 +20,13 @@
 import CwlViews
 
 struct PickerViewState: CodableContainer {
-	var selectedRow: TempVar<PickerRowAndComponent>
+	var selectedRow: TempVar<PickerView<String>.RowComponentAndData>
 	init() {
-		selectedRow = TempVar<PickerRowAndComponent>()
+		selectedRow = TempVar<PickerView<String>.RowComponentAndData>()
 	}
 }
 
 func pickerView(_ viewState: PickerViewState, _ navigationItem: NavigationItem) -> ViewControllerConvertible {
-	//let moreFirstThing = PickerComponent<Void>.ComponentType.text("hello")
-    //let firstThing = PickerComponent<Void>(width: 100,  rowHeight: 50, elements: [])
-	//let things: Dynamic<PickerComponentMutation<PickerComponent<Void>>> = .reload([PickerComponent<Void>(width: 100,  rowHeight: 50, elements: [.text("1"), .text("2"), .text("3")])])
-//	PickerView<Void>(
-//		.backgroundColor -- .red,
-//		.pickerData -- .reload([PickerComponent<Void>(elements: [.text("1"), .text("2"), .text("3")])]),
-//		.row
-//	)
-
 	return ViewController(
 		.navigationItem -- navigationItem,
 		.view -- View(
@@ -44,7 +35,7 @@ func pickerView(_ viewState: PickerViewState, _ navigationItem: NavigationItem) 
 				marginEdges: .allLayout,
 				.view(
 					Label(
-						.text <-- viewState.selectedRow.map { value in return "\(value)"},
+						.text <-- viewState.selectedRow.map { value in return "\(value.data)"},
 						.font -- UIFont.monospacedDigitSystemFont(ofSize: 17, weight: .regular)
 					)
 				),
@@ -52,19 +43,15 @@ func pickerView(_ viewState: PickerViewState, _ navigationItem: NavigationItem) 
 				.view(
 					PickerView<String>(
 						.backgroundColor -- .red,
-						.pickerData -- .reload([PickerComponent<String>(elements: [.text("1"), .text("2"), .text("3"), .view("4")]), PickerComponent<String>(elements: [.text("5"), .text("6"), .text("7"), .view("🏁")])]),
+						.pickerData -- .reload([PickerComponent<String>(elements: ["1", "2", "3", "4"]), PickerComponent<String>(elements: ["1", "2", "3", "4"])]),
 						.rowSelected --> viewState.selectedRow,
-						.viewConstructor -- { data in
-							Label(.text <-- data)
-						}
+						.title -- { $0.data }
+//						.viewConstructor -- { data in
+//							Label(.text <-- data.map { $0.data})
+//						}
 					)
 				)
 			)
 		)
 	)
 }
-/*
-.cellConstructor -- { reuseIdentifier, cellData in
-TableViewCell(.textLabel -- Label(.text <-- cellData.map { data in data.localizedString }))
-}
-*/

--- a/Tests/CwlViewsCatalog_iOS/Sources/PickerView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/PickerView.swift
@@ -1,0 +1,62 @@
+//
+//  PickerView.swift
+//  CwlViewsCatalog_iOS
+//
+//  Created by Sye Boddeus on 22/5/19.
+//  Copyright © 2019 Matt Gallagher ( https://www.cocoawithlove.com ). All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+//  fee is hereby granted, provided that the above copyright notice and this permission notice
+//  appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+//  SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+//  AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+//  NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+//  OF THIS SOFTWARE.
+//
+
+import CwlViews
+
+struct PickerViewState: CodableContainer {
+	var selectedRow: TempVar<PickerRowAndComponent>
+	init() {
+		selectedRow = TempVar<PickerRowAndComponent>()
+	}
+}
+
+func pickerView(_ viewState: PickerViewState, _ navigationItem: NavigationItem) -> ViewControllerConvertible {
+	//let moreFirstThing = PickerComponent<Void>.ComponentType.text("hello")
+    //let firstThing = PickerComponent<Void>(width: 100,  rowHeight: 50, elements: [])
+	//let things: Dynamic<PickerComponentMutation<PickerComponent<Void>>> = .reload([PickerComponent<Void>(width: 100,  rowHeight: 50, elements: [.text("1"), .text("2"), .text("3")])])
+//	PickerView<Void>(
+//		.backgroundColor -- .red,
+//		.pickerData -- .reload([PickerComponent<Void>(elements: [.text("1"), .text("2"), .text("3")])]),
+//		.row
+//	)
+
+	return ViewController(
+		.navigationItem -- navigationItem,
+		.view -- View(
+			.backgroundColor -- .white,
+			.layout -- .center(
+				marginEdges: .allLayout,
+				.view(
+					Label(
+						.text <-- viewState.selectedRow.map { value in return "\(value)"},
+						.font -- UIFont.monospacedDigitSystemFont(ofSize: 17, weight: .regular)
+					)
+				),
+				.space(),
+				.view(
+					PickerView<Void>(
+						.backgroundColor -- .red,
+						.pickerData -- .reload([PickerComponent<Void>(elements: [.text("1"), .text("2"), .text("3")])]),
+						.rowSelected --> viewState.selectedRow
+					)
+				)
+			)
+		)
+	)
+}

--- a/Tests/CwlViewsCatalog_iOS/Sources/PickerView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/PickerView.swift
@@ -50,13 +50,21 @@ func pickerView(_ viewState: PickerViewState, _ navigationItem: NavigationItem) 
 				),
 				.space(),
 				.view(
-					PickerView<Void>(
+					PickerView<String>(
 						.backgroundColor -- .red,
-						.pickerData -- .reload([PickerComponent<Void>(elements: [.text("1"), .text("2"), .text("3")])]),
-						.rowSelected --> viewState.selectedRow
+						.pickerData -- .reload([PickerComponent<String>(elements: [.text("1"), .text("2"), .text("3"), .view("4")])]),
+						.rowSelected --> viewState.selectedRow,
+						.viewConstructor -- { data in
+							Label(.text <-- data)
+						}
 					)
 				)
 			)
 		)
 	)
 }
+/*
+.cellConstructor -- { reuseIdentifier, cellData in
+TableViewCell(.textLabel -- Label(.text <-- cellData.map { data in data.localizedString }))
+}
+*/

--- a/Tests/CwlViewsCatalog_iOS/Sources/PickerView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/PickerView.swift
@@ -52,7 +52,7 @@ func pickerView(_ viewState: PickerViewState, _ navigationItem: NavigationItem) 
 				.view(
 					PickerView<String>(
 						.backgroundColor -- .red,
-						.pickerData -- .reload([PickerComponent<String>(elements: [.text("1"), .text("2"), .text("3"), .view("4")])]),
+						.pickerData -- .reload([PickerComponent<String>(elements: [.text("1"), .text("2"), .text("3"), .view("4")]), PickerComponent<String>(elements: [.text("5"), .text("6"), .text("7"), .view("🏁")])]),
 						.rowSelected --> viewState.selectedRow,
 						.viewConstructor -- { data in
 							Label(.text <-- data)

--- a/Tests/CwlViewsCatalog_iOS/Sources/SplitView.swift
+++ b/Tests/CwlViewsCatalog_iOS/Sources/SplitView.swift
@@ -55,6 +55,7 @@ func splitView(_ viewState: SplitViewState) -> ViewControllerConvertible {
 				case .layers(let state)?: return layersView(state, navigationItem)
 				case .navigationBar(let state)?: return navigationView(state, navigationItem)
 				case .pageViewController(let state)?: return pageView(state, navigationItem)
+				case .pickerView(let state)?: return pickerView(state, navigationItem)
 				case .progressView(let state)?: return progressView(state, navigationItem)
 				case .searchBar(let state)?: return searchBarView(state, navigationItem)
 				case .segmentedControl(let state)?: return segmentedControlView(state, navigationItem)


### PR DESCRIPTION
This was tricker than I original anticipated and I have taken a lot of liberties and best guesses with the implementation, so I am definitely looking for some feedback as I am not happy, but I am also a little stuck 🙃

I will add inline comments to this PR to highlight the parts I am unsure about and provide reasons why I made certain decisions that may otherwise appear odd.

Some notes:
- The implementation is inspired by the TableView implementation, even though `UIPickerViewDelegate` and `UIPickerViewDataSource` behave differently to their `UITableView` counterparts.
- The majority of those delegate and data source methods are hidden, unlike `TableView`, because I felt providing the `pickerData` binding reduces the need for them to be exposed. (I did a similar thing for the segment control).
- `UIPickerView` does not allow reloading of individual rows, just individual components or all components. Similarly, row height and column width are specified at the component level. So I created a component descriptor that contains all the row elements as an array. This feels restrictive and I am open to suggestions on how to improve it.

Thanks.